### PR TITLE
MaF permissions to relicense as GPL

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -19,6 +19,17 @@ This file lists the contributors to the Conquer game project.
 - Active in USENET community discussions
 - Copyright holder (1987-1988)
 
+## Additional Original Contributors (1989)
+** Martin Forssen (MaF)** <d8forma@dtek.chalmers.se> (historical)> / <maf@recordedfuture.com> (current)
+*PostScript utilities author*
+
+- Created psmap.c - PostScript map generator for Conquer
+- Developed CONQPS.INFO documentation and utilities
+- Created PostScript visualization components
+- Original "Feel free to hack" licensing approach
+- Copyright holder for PostScript utilities (1989)
+- Granted GPL v3 relicensing permission (2025)
+
 ## Historical Context
 
 The original Conquer was developed during the late 1980s when source code was commonly distributed through USENET newsgroups. Both authors contributed significantly to early computer gaming and open source distribution methods.
@@ -78,6 +89,7 @@ The original Conquer was developed during the late 1980s when source code was co
 - **Juan Manuel Méndez Rey (Vejeta)**: Legal coordination, author contact, documentation
 - **Ed Barlow**: Permission granting, historical clarification
 - **Adam Bryant**: Permission confirmation, copyright clarification
+- **Martin Forssen**: PostScript utilities, relicensing permission (2025)
 
 ### Current Era (2011-present)
 - **Vejeta**: Primary maintainer, documentation, community coordination

--- a/CONQPS.INFO
+++ b/CONQPS.INFO
@@ -1,4 +1,26 @@
+CONQPS.INFO - A program to convert conquer maps to postscript
 
+This file is part of Conquer.
+Originally Copyright (C) 1989 by Martin Forssen (MaF)
+Copyright (C) 2025 Juan Manuel Méndez Rey (Vejeta) - Licensed under GPL v3 with permission from original author
+
+Original author: Martin Forssen <d8forma@dtek.chalmers.se> (historical)
+Permission granted by: Martin Forssen <maf@recordedfuture.com>
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+================================================================================
 
   Description
 
@@ -22,9 +44,9 @@ a LaserWriter II.
   c  Turns off printing of coordinates around the edge of the map.
 
   f fontname  Sets the font to 'fontname', you can use any font that is in your
-	      printer. Default is Times-Roman. The program also looks for
-	      the environment variable CONQ_PSFONT. The f option overrides
-	      both the default and the environment variable.
+          printer. Default is Times-Roman. The program also looks for
+          the environment variable CONQ_PSFONT. The f option overrides
+          both the default and the environment variable.
   
   g  Turns off printing of the grid at the unknown parts of the map.
 
@@ -41,24 +63,24 @@ a LaserWriter II.
 
   o x,y  If you want to print just a small part of a bigger map use this
          option. It makes conqps just to produce one page centered around
-	 coordinates x,y.
+     coordinates x,y.
 
   p type  Sets the type of paper you have in the printer. Possible values
-	  today are: A4 (European standard) LETTER (American standard) or
-	  OTHER (should be local standard). You shouldn't have to use this
-	  option since the person who maintains conquer at your site should
-	  have set the right papersize as default (This is done in the
-	  Makefile).
+      today are: A4 (European standard) LETTER (American standard) or
+      OTHER (should be local standard). You shouldn't have to use this
+      option since the person who maintains conquer at your site should
+      have set the right papersize as default (This is done in the
+      Makefile).
 
   s size  Sets the size of each square of the map. This is useful to get
-	  more map printed on fewer pages, but it will be smaller.
-	  Default value is 9.
+      more map printed on fewer pages, but it will be smaller.
+      Default value is 9.
 
   t string  Conqps tries to guess a nice title to the map for you. Normally
-	    this is something like 'Designation Map for Nation Midkemia on
-	    Turn 2' (this title is actually provided from the conquer program).
-	    If however you would like to have your own title shown, just use
-	    the t option, which replaces the default title with string.
+        this is something like 'Designation Map for Nation Midkemia on
+        Turn 2' (this title is actually provided from the conquer program).
+        If however you would like to have your own title shown, just use
+        the t option, which replaces the default title with string.
 
   u  Normally conqps put small pictures in some of your squares instead of
      just letters. This option forces conqps not to do this, but instead
@@ -68,21 +90,20 @@ a LaserWriter II.
      is and how big it will be on the printer.
 
   L,W,X,Y  If none of the paper types fits your needs you can alter the size
-	   directly with these options. All these options use one postscript
-	   point (1/72 inch) as their unit. L sets the length of the page.
-	   W sets the width. X sets the x coordinate for the leftmost viewable
-	   pixel on the output, and Y sets the y coordinate. These options
-	   are normally never used, instead you should experiment with
-	   the p option.
+       directly with these options. All these options use one postscript
+       point (1/72 inch) as their unit. L sets the length of the page.
+       W sets the width. X sets the x coordinate for the leftmost viewable
+       pixel on the output, and Y sets the y coordinate. These options
+       are normally never used, instead you should experiment with
+       the p option.
 
   Bugs
 
  Hopefully no.
 
-
   Comments
 
- If you have any comments or ideas mail them to d8forma@dtek.chalmers.se  .
+ For questions about this GPL v3 licensed version, contact the current maintainer.
+ For historical reference, original author was Martin Forssen (MaF).
 
-						MaF
-
+                   Originally by MaF, GPL v3 licensed with permission

--- a/HISTORY.md
+++ b/HISTORY.md
@@ -75,6 +75,12 @@ Conquer is a Middle Earth multi-player strategy game that was originally distrib
 
 The game's distribution method through USENET was typical of the era, when source code was shared across newsgroups and assembled by users from multiple parts posted sequentially.
 
+## PostScript Utilities
+
+Martin Forssen's PostScript utilities added professional map printing capabilities to Conquer, allowing players to generate high-quality printed maps suitable for PostScript printers. 
+
+This was particularly valuable in the era before widespread graphical user interfaces, providing a way to visualize the game state in print.
+
 ## Legacy
 
 This historical documentation preserves the timeline of one of the early multi-player computer games and demonstrates the evolution of open source software licensing practices. The successful relicensing effort by Vejeta (2006-2011) serves as an example of how legacy software can be preserved and made available to modern audiences under open source licenses.

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -21,6 +21,8 @@ See the full text of the GPL-3.0 license in the file `GPL-3.0.txt` included with
 
 2. **Adam Bryant (2011):** *"Just wanted to confirm that I had no issues with publication of version 4 of Conquer under the GPL."* - Confirmed permission to release under GPL.
 
+3. **Martin Forssen (MaF) (2025):** *"And I have no problem with relicensing it to GPL."* - Granted permission to relicense under GPL.
+
 ### Legal Documentation
 
 **⚠️ COMPLETE EMAIL EVIDENCE:** The full, unedited email correspondence containing the explicit relicensing permissions from both original authors is preserved in [`RELICENSING-PERMISSIONS.md`](RELICENSING-PERMISSIONS.md) for legal compliance and transparency.
@@ -40,7 +42,8 @@ You should have received a copy of the GNU General Public License along with thi
 - Original USENET posts and historical references can be found in [`HISTORY.md`](HISTORY.md)
 - The relicensing process began in 2006 when Vejeta contacted the original authors
 - This relicensing effort was discussed on Debian Legal mailing lists and other forums
-- All source code extraction and compilation from original USENET posts was performed by the maintainer
+- All source code extraction and compilation from original USENET posts was performed by the maintainer and **quixadhal (Dread Quixadhal)** - https://github.com/quixadhal
+- PostScript utilities by Martin Forssen were relicensed in 2025
 
 ## Files in This Repository
 
@@ -54,6 +57,6 @@ You should have received a copy of the GNU General Public License along with thi
 
 **Repository Maintainer:** Juan Manuel Méndez Rey (Vejeta)
 **Relicensing Contact:** vejeta@gmail.com  
-**Last Updated:** 13th September 2025
+**Last Updated:** 15th September 2025
 
 **For complete legal documentation:** See [`RELICENSING-PERMISSIONS.md`](RELICENSING-PERMISSIONS.md)

--- a/RELICENSING-PERMISSIONS.md
+++ b/RELICENSING-PERMISSIONS.md
@@ -721,6 +721,243 @@ lege partners will be happy with the news.</div>
 
 ---
 
+## Permission from Martin Forssen (2025)
+
+**Context:** Martin Forssen (MaF) was a contributor for psmap.c, psmap.h, psmap.ps and CONQPS.INFO, 
+a tool to convert conquer maps to postscript. Contact established in 2025, providing explicit GPL permission.
+
+**Key Quote:** *"Oh, that was a long time ago. But yes, that was me. And I have no problem
+with relicensing it to GPL."*
+
+### Complete Email Evidence
+
+```
+Delivered-To: vejeta@gmail.com
+Received: by 2002:a05:6214:3189:b0:771:2ea2:b9a5 with SMTP id lb9csp1064900qvb;
+        Sun, 14 Sep 2025 23:07:41 -0700 (PDT)
+X-Received: by 2002:a05:690c:6a87:b0:721:c0d:9dd9 with SMTP id 00721157ae682-7306609c65amr96296677b3.52.1757916461647;
+        Sun, 14 Sep 2025 23:07:41 -0700 (PDT)
+ARC-Seal: i=1; a=rsa-sha256; t=1757916461; cv=none;
+        d=google.com; s=arc-20240605;
+        b=jmKNV1niB+TRLg4cEsg6KS2TmlbvGECyvjY13X5HuxpVkqJwaBmVV6f+dwluGbxx1T
+         GkIz4Bqt6600qu0nbbzdDaqGHZOgf5KiBLy6koGZqxDmJPfR6xszCpsOEAIvU50glSMI
+         pQ9zKSfMoASQQ2LqktKM+Wrbm/X7Lwz8WlWrSIS9X11ndYHyia5ZZaTJY9cKmpJlg7Gf
+         7Dqc/Hy6q3jEH68pBWRhGb/Or0IExwfGgCD6vbvDjnN6HueW6frTa5Brqlcx178/RXFJ
+         iaYK7/Hhg9PaOo4jFef6p/dStMRyhN54IWDnjx3awNE9dPapZRjzw3yHymurRZsT0tFP
+         r6lQ==
+ARC-Message-Signature: i=1; a=rsa-sha256; c=relaxed/relaxed; d=google.com; s=arc-20240605;
+        h=to:subject:message-id:date:from:in-reply-to:references:mime-version
+         :dkim-signature;
+        bh=+JCYV0wGpX8SKyUGN6Rey2Qzp5qHgnZHagpNto9OweY=;
+        fh=21tBcJpjA6s6ZIz3rrnEJwEKqE4tqy4BRFXeBxNoNzE=;
+        b=Rx4NAn61KqmhWSAfoOlbPhju2/PvWUGou7Y3LGfO3fkxcQX6bGuO7BbPnKPMfVJg6w
+         QNZ0FjUhSSL2bXuIVqKMEnHo+HlXZh/Lll/F15HVF8uue+p3wTfc2JjUDMf4mHugXAtr
+         4bfnKJtTBQDzuA33eor/9i7pw9q6XrQz2jWF2ICLcgI0f5hHM2UZKWVnQ4FxJxpZXDU9
+         iIk7NYxtvoFf6Fa6mQztftrvw2NmPbPvZh3f8TrXO6665IcW1t1RL91c7oXnH0wvsfcS
+         MFmU3NCFUBV8gCrVouV4BZGsuUakkWnja5i7bNZI+P+pBvHUBDCdvGxwygx0RshRDezu
+         zCeQ==;
+        dara=google.com
+ARC-Authentication-Results: i=1; mx.google.com;
+       dkim=pass header.i=@recordedfuture.com header.s=google header.b=IULv9xlC;
+       spf=pass (google.com: domain of maf@recordedfuture.com designates 209.85.220.41 as permitted sender) smtp.mailfrom=maf@recordedfuture.com;
+       dmarc=pass (p=REJECT sp=REJECT dis=NONE) header.from=recordedfuture.com;
+       dara=pass header.i=@gmail.com
+Return-Path: <maf@recordedfuture.com>
+Received: from mail-sor-f41.google.com (mail-sor-f41.google.com. [209.85.220.41])
+        by mx.google.com with SMTPS id 956f58d0204a3-629d23ab243sor2374253d50.14.2025.09.14.23.07.41
+        for <vejeta@gmail.com>
+        (Google Transport Security);
+        Sun, 14 Sep 2025 23:07:41 -0700 (PDT)
+Received-SPF: pass (google.com: domain of maf@recordedfuture.com designates 209.85.220.41 as permitted sender) client-ip=209.85.220.41;
+Authentication-Results: mx.google.com;
+       dkim=pass header.i=@recordedfuture.com header.s=google header.b=IULv9xlC;
+       spf=pass (google.com: domain of maf@recordedfuture.com designates 209.85.220.41 as permitted sender) smtp.mailfrom=maf@recordedfuture.com;
+       dmarc=pass (p=REJECT sp=REJECT dis=NONE) header.from=recordedfuture.com;
+       dara=pass header.i=@gmail.com
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=recordedfuture.com; s=google; t=1757916461; x=1758521261; dara=google.com;
+        h=to:subject:message-id:date:from:in-reply-to:references:mime-version
+         :from:to:cc:subject:date:message-id:reply-to;
+        bh=+JCYV0wGpX8SKyUGN6Rey2Qzp5qHgnZHagpNto9OweY=;
+        b=IULv9xlCcYqjs2pFrAxu2GrkqxkV9hXj7AKDUmda+K8znW01PLGSZKsmWNcXYsLh7o
+         7mEsMMV848XUO0u0wfS/cj1JHKe/tmuufGyqEJkRaue/btaP91l+XUcydW523bcdqaP1
+         pHqC6ROmpF59Pyzr6Cr+4kvPSQ7OzCtco6fiQ=
+X-Google-DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/relaxed;
+        d=1e100.net; s=20230601; t=1757916461; x=1758521261;
+        h=to:subject:message-id:date:from:in-reply-to:references:mime-version
+         :x-gm-message-state:from:to:cc:subject:date:message-id:reply-to;
+        bh=+JCYV0wGpX8SKyUGN6Rey2Qzp5qHgnZHagpNto9OweY=;
+        b=wV9H0rZAZ13r3eIxJC6sUEjAnHVx57S22N0vh9FPGRmMKrIGaUvDp0xPl0oAK80/ik
+         k9XrVTyalGoybkMPOiY7KNRbbWVbxVFF839DwbPzOLZniHGH7P/eVh0x7yNEryHRtIbe
+         nuCjLR3CTRySGEmOpFj7haG21SuU3jcXiCeMyrzmK8QRdEFnhFoH7yn7SmZt1QYx/68g
+         +r2fy6UArA33sc2tM8Vf9uZnsBPc9VU8DoH/L6+EwOY3sBbOQJazM6w46egzYW/nQgyd
+         1kHwCR1UcPyGM08PTXbV3sGmfBWYMv6lOe2I0o6n3p/g57vbYH8cDHXJgSFUj4NL1mGq
+         fpvg==
+X-Gm-Message-State: AOJu0YxeLEigEXZPXsOXHqbdIF1p6t1prsTH+RQeVzmNTXbHkejWDO7g 6e9szXI78U4kUyhLM3uFZ/2W/x2C+LqDXu+R6zh/vS10XKaycNLn4f/PbRH4e1Qg2Zn9SLJbI5p /iwtJJ6M16OhwQWTQbbMpOgPKKcDwwGFGRTIQhJXsPQHqc2hJKJSRdWM=
+X-Gm-Gg: ASbGncu61X+w51VCht3BNt6nl5dyZYjjN5OtK2s/vle3OOylnkKwT7mPSd3U7S0ZxpC 0cE3A9pXc0HpON7rCoY3upf+Oc91aMZ4OtP6eL6LKQv0QYKQupxJcerGX4/u11vB1MX3AtfC+RF LTln1rDoEkXGEr/eMZTrJCZSEYwes+T1PDSxdyPB2KJEdpGzxqB8ZZ5Xu2O76ngvPcp7Evy9cXy JcmVCM11PGdLOj2Bx0=
+X-Google-Smtp-Source: AGHT+IGwD8DnYOX7m7E/6Eq1voDV1H6Rv82BDypfP6ozhLIuOk60SVc9XJmPl2wrAo+2ZfTbLERfdQatoRhEB77LvIs=
+X-Received: by 2002:a05:690e:159b:20b0:62b:3ee0:6d07 with SMTP id 956f58d0204a3-62b3ee06ed7mr5164533d50.3.1757916460625; Sun, 14 Sep 2025 23:07:40 -0700 (PDT)
+MIME-Version: 1.0
+References: <CAPRyRFn3VcAakEuLsQkR5sCzpAR0O2S6_Ukf16YpkSCkX_MRVQ@mail.gmail.com> <CAPRyRFmoD4ixgCg7VLRcnVP=YqzKvV8Y0PHwaYxxfFju0zy1hQ@mail.gmail.com> <CAPRyRFkWo2UGRy3opRzni-0a5s8Ukvyo46Uwxa924L5A9DP5=A@mail.gmail.com>
+In-Reply-To: <CAPRyRFkWo2UGRy3opRzni-0a5s8Ukvyo46Uwxa924L5A9DP5=A@mail.gmail.com>
+From: Martin Forssen <maf@recordedfuture.com>
+Date: Mon, 15 Sep 2025 08:07:29 +0200
+X-Gm-Features: Ac12FXxmtXrXwDFXGs5SqsZZ3PSolUaHHISJz7kR1IPmMdeREAja53_PnM8KoCM
+Message-ID: <CAL3e5LtbasXXyGmBON5_aDJRMuJXhHhYCvk6p+Jo8-UOmPZpCw@mail.gmail.com>
+Subject: Re: Conquer (Unix computer game) relicensing
+To: Juan Mendez <vejeta@gmail.com>
+Content-Type: multipart/alternative; boundary="0000000000002e4f39063ed0d288"
+
+--0000000000002e4f39063ed0d288
+Content-Type: text/plain; charset="UTF-8"
+Content-Transfer-Encoding: quoted-printable
+
+Oh, that was a long time ago. But yes, that was me. And I have no problem
+with relicensing it to GPL.
+
+    /MaF
+
+On Sun, Sep 14, 2025 at 12:38=E2=80=AFPM Juan Mendez <vejeta@gmail.com> wro=
+te:
+
+> Hi Martin, I am currently in the process of relicensing Conquer. Do
+> you remember that old game?
+>
+> I am a computer developer from Spain. I was a university student at
+> the beginning of the 90s.
+> I found your email by looking in
+> https://github.com/vejeta/conquer/blob/master/CONQPS.INFO
+>
+> Looking for the email address, I thought it might belong to you.
+> ```
+> d8forma@dtek.chalmers.se (Martin Fors sen)
+> ```
+> In case it is you, one of the contributors for the conqps utility, I
+> would like to contact you for having relicensing permissions to GPL
+> v3, otherwise, I will be removing the old code. Please, contact
+> me if you read this.
+>
+> I started the project of preserving the legacy of Conquer 20 years ago
+> by contacting Edward Barlow and Adam Bryant first, and finally, I
+> believe it is close to completion.
+>
+> Wishing you the best,
+>
+> Juan
+>
+> --
+> http://vejeta.com
+> Fidonet: 2:345/432.2
+> I'm an FSF member -- Help us support software freedom!
+> https://my.fsf.org/join?referrer=3D327575
+>
+>
+> --
+> http://vejeta.com
+> Fidonet: 2:345/432.2
+> I'm an FSF member -- Help us support software freedom!
+> https://my.fsf.org/join?referrer=3D327575
+>
+
+
+--=20
+
+Martin Forss=C3=A9n
+
+Director of Product Security
+
+Recorded Future <https://www.recordedfuture.com/>
+
++46 760 252357
+
+maf@recordedfuture.com
+
+--0000000000002e4f39063ed0d288
+Content-Type: text/html; charset="UTF-8"
+Content-Transfer-Encoding: quoted-printable
+
+<div dir=3D"ltr"><div>Oh, that was a long time ago. But yes, that was me. A=
+nd I have no problem with relicensing it to GPL.</div><div><br></div><div>=
+=C2=A0 =C2=A0 /MaF</div></div><br><div class=3D"gmail_quote gmail_quote_con=
+tainer"><div dir=3D"ltr" class=3D"gmail_attr">On Sun, Sep 14, 2025 at 12:38=
+=E2=80=AFPM Juan Mendez &lt;<a href=3D"mailto:vejeta@gmail.com">vejeta@gmai=
+l.com</a>&gt; wrote:<br></div><blockquote class=3D"gmail_quote" style=3D"ma=
+rgin:0px 0px 0px 0.8ex;border-left:1px solid rgb(204,204,204);padding-left:=
+1ex">Hi Martin, I am currently in the process of relicensing Conquer. Do<br=
+>
+you remember that old game?<br>
+<br>
+I am a computer developer from Spain. I was a university student at<br>
+the beginning of the 90s.<br>
+I found your email by looking in<br>
+<a href=3D"https://github.com/vejeta/conquer/blob/master/CONQPS.INFO" rel=
+=3D"noreferrer" target=3D"_blank">https://github.com/vejeta/conquer/blob/ma=
+ster/CONQPS.INFO</a><br>
+<br>
+Looking for the email address, I thought it might belong to you.<br>
+```<br>
+<a href=3D"mailto:d8forma@dtek.chalmers.se" target=3D"_blank">d8forma@dtek.=
+chalmers.se</a> (Martin Fors sen)<br>
+```<br>
+In case it is you, one of the contributors for the conqps utility, I<br>
+would like to contact you for having relicensing permissions to GPL<br>
+v3, otherwise, I will be removing the old code. Please, contact<br>
+me if you read this.<br>
+<br>
+I started the project of preserving the legacy of Conquer 20 years ago<br>
+by contacting Edward Barlow and Adam Bryant first, and finally, I<br>
+believe it is close to completion.<br>
+<br>
+Wishing you the best,<br>
+<br>
+Juan<br>
+<br>
+--<br>
+<a href=3D"http://vejeta.com" rel=3D"noreferrer" target=3D"_blank">http://v=
+ejeta.com</a><br>
+Fidonet: 2:345/432.2<br>
+I&#39;m an FSF member -- Help us support software freedom!<br>
+<a href=3D"https://my.fsf.org/join?referrer=3D327575" rel=3D"noreferrer" ta=
+rget=3D"_blank">https://my.fsf.org/join?referrer=3D327575</a><br>
+<br>
+<br>
+-- <br>
+<a href=3D"http://vejeta.com" rel=3D"noreferrer" target=3D"_blank">http://v=
+ejeta.com</a><br>
+Fidonet: 2:345/432.2<br>
+I&#39;m an FSF member -- Help us support software freedom!<br>
+<a href=3D"https://my.fsf.org/join?referrer=3D327575" rel=3D"noreferrer" ta=
+rget=3D"_blank">https://my.fsf.org/join?referrer=3D327575</a><br>
+</blockquote></div><div><br clear=3D"all"></div><br><span class=3D"gmail_si=
+gnature_prefix">-- </span><br><div dir=3D"ltr" class=3D"gmail_signature"><d=
+iv dir=3D"ltr"><div><div dir=3D"ltr"><span><p dir=3D"ltr" style=3D"line-hei=
+ght:1.38;margin-top:0pt;margin-bottom:0pt"><span style=3D"font-size:13.3333=
+px;font-family:Arial;color:rgb(0,0,0);font-weight:700;vertical-align:baseli=
+ne;white-space:pre-wrap;background-color:transparent">Martin Forss=C3=A9n</=
+span></p><p dir=3D"ltr" style=3D"line-height:1.38;margin-top:0pt;margin-bot=
+tom:0pt"><span style=3D"font-size:13.3333px;font-family:Arial;color:rgb(0,0=
+,0);font-style:italic;vertical-align:baseline;white-space:pre-wrap;backgrou=
+nd-color:transparent">Director of Product Security</span></p><p dir=3D"ltr"=
+ style=3D"line-height:1.38;margin-top:0pt;margin-bottom:0pt"><a href=3D"htt=
+ps://www.recordedfuture.com/" style=3D"text-decoration:none" target=3D"_bla=
+nk"><span style=3D"font-size:13.3333px;font-family:Arial;text-decoration:un=
+derline;vertical-align:baseline;white-space:pre-wrap;background-color:trans=
+parent">Recorded Future</span></a><span style=3D"font-size:13.3333px;font-f=
+amily:Arial;color:rgb(0,0,0);vertical-align:baseline;white-space:pre-wrap;b=
+ackground-color:transparent"></span></p><p dir=3D"ltr" style=3D"line-height=
+:1.38;margin-top:0pt;margin-bottom:0pt"><span style=3D"font-size:13.3333px;=
+font-family:Arial;color:rgb(0,0,0);vertical-align:baseline;white-space:pre-=
+wrap;background-color:transparent">+46 760 252357<br></span></p><p style=3D=
+"line-height:1.38;margin-top:0pt;margin-bottom:0pt"><span style=3D"font-siz=
+e:13.3333px;font-family:Arial;color:rgb(0,0,0);vertical-align:baseline;whit=
+e-space:pre-wrap;background-color:transparent"><a href=3D"mailto:maf@record=
+edfuture.com" target=3D"_blank">maf@recordedfuture.com</a><br></span></p></=
+span></div></div></div></div>
+
+--0000000000002e4f39063ed0d288--
+```
+
+
 ## Legal Analysis and Validation
 
 ### Permission Summary

--- a/psmap.c
+++ b/psmap.c
@@ -1,10 +1,13 @@
 /*
- * psmap.c - Game functionality module
- * 
+ * psmap.c - A program to convert conquer-maps to postscript
+ *
  * This file is part of Conquer.
- * Originally Copyright (C) 1988-1989 by Edward M. Barlow and Adam Bryant
- * Copyright (C) 2025 Juan Manuel Méndez Rey (Vejeta) - Licensed under GPL v3 with permission from original authors
- * 
+ * Originally Copyright (C) 1989 by Martin Forssen (MaF)
+ * Copyright (C) 2025 Juan Manuel Méndez Rey (Vejeta) - Licensed under GPL v3 with permission from original author
+ *
+ * Original author: Martin Forssen <d8forma@dtek.chalmers.se> (historical)
+ * Permission granted by: Martin Forssen <maf@recordedfuture.com>
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or

--- a/psmap.h
+++ b/psmap.h
@@ -1,9 +1,13 @@
 /*
- * psmap.h - Header file with definitions and prototypes
- * 
+/*
+ * psmap.c - Header file for conqps. A program to convert conquer-maps to postscript
+ *
  * This file is part of Conquer.
- * Originally Copyright (C) 1988-1989 by Edward M. Barlow and Adam Bryant
- * Copyright (C) 2025 Juan Manuel Méndez Rey (Vejeta) - Licensed under GPL v3 with permission from original authors
+ * Originally Copyright (C) 1989 by Martin Forssen (MaF)
+ * Copyright (C) 2025 Juan Manuel Méndez Rey (Vejeta) - Licensed under GPL v3 with permission from original author
+ *
+ * Original author: Martin Forssen <d8forma@dtek.chalmers.se> (historical)
+ * Permission granted by: Martin Forssen <maf@recordedfuture.com>
  * 
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by

--- a/psmap.ps
+++ b/psmap.ps
@@ -1,6 +1,24 @@
-%% Postscript part of conqps
-%% Feel free to hack in it
-%% Comments should be sent to  d8forma@dtek.chalmers.se
+%% PostScript part of conqps - Map visualization for Conquer
+%%
+%% This file is part of Conquer.
+%% Originally Copyright (C) 1989 by Martin Forssen (MaF)
+%% Copyright (C) 2025 Juan Manuel Méndez Rey (Vejeta) - Licensed under GPL v3 with permission from original author
+%%
+%% Original author: Martin Forssen <d8forma@dtek.chalmers.se> (historical)
+%% Permission granted by: Martin Forssen <maf@recordedfuture.com>
+%%
+%% This program is free software: you can redistribute it and/or modify
+%% it under the terms of the GNU General Public License as published by
+%% the Free Software Foundation, either version 3 of the License, or
+%% (at your option) any later version.
+%%
+%% This program is distributed in the hope that it will be useful,
+%% but WITHOUT ANY WARRANTY; without even the implied warranty of
+%% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%% GNU General Public License for more details.
+%%
+%% You should have received a copy of the GNU General Public License
+%% along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 %   This is the user variables
 


### PR DESCRIPTION
This contains the update with the permissions from MaF, the original conqps contributor to be able to include those files relicensed as GPL v3. Headers and relevant files has been updated to maintain the attribution.