### PR TITLE
Make it compilable in GNU/Linux. 

### DIFF
--- a/admin.c
+++ b/admin.c
@@ -53,9 +53,13 @@ short	dismode=2;
 /* nation id of owner*/
 short	country=0;
 struct	s_nation	*curntn;
-extern char datadir[];
-char scenario[256];
-//char defaultdir[256];
+
+/* External declaration for datadir which is defined in makeworl.c */
+extern char datadir[FILELTH];
+
+/* Note: scenario is already declared in data.h when ADMIN is defined */
+/* char scenario[256]; -- REMOVED to avoid conflict */
+
 #ifdef REMAKE
 int	remake=FALSE;
 #endif /*REMAKE*/

--- a/forms.c
+++ b/forms.c
@@ -500,7 +500,7 @@ change()
 
 #ifdef OGOD
 	if(isgod==TRUE) mvaddstr(LINES-3,COLS/2-33,"HIT 8 TO DESTROY, 9 TO CHANGE COMMODITY OR '0' TO CHANGE DEMI-GOD");
-#else OGOD
+#else
 	if(isgod==TRUE) mvaddstr(LINES-3,COLS/2-24,"HIT 8 TO DESTROY NATION, OR '0' TO CHANGE DEMI-GOD");
 #endif /* OGOD */
 	else mvaddstr(LINES-3,COLS/2-14,"HIT ANY OTHER KEY TO CONTINUE");

--- a/header.h
+++ b/header.h
@@ -20,8 +20,10 @@
  */
 
 /* --- MODIFICATION IS REQUIRED OF THE FOLLOWING DEFINE STATEMENTS ---	*/
-#define OWNER	"Adam Bryant"	/* administrators name			*/
-#define LOGIN	"adb"		/* administrators login id. IMPORTANT!	*/
+#define OWNER	"God"	/* administrators name			*/
+#ifndef LOGIN
+#define LOGIN "defaultuser" /* administrators login id. IMPORTANT!	*/
+#endif
                 		/* only this UID may update.		*/
 /* #define SYSV		/* uncomment this line on a UNIX SYSV machine	*/
 #define BSD		/* uncomment this line on a BSD machine		*/
@@ -57,7 +59,7 @@
 			/* this allows demi-gods the ability to remake  */
 			/* their world.                                 */
 #define NOSCORE		/* only show full scores to god while in game	*/
-/* #define CHECKUSER */	/* only allow owner of nation to play it        */
+#define CHECKUSER 	/* only allow owner of nation to play it        */
 #define REVSPACE 5	/* allow for this many revolts in nation list   */
 #define LASTADD 5	/* last turn players may w/out password         */
 #define USERLOG		/* log users who play a nation                  */

--- a/main.c
+++ b/main.c
@@ -305,7 +305,9 @@ char	**argv;
 		if (pflag != FALSE)
 			fprintf(stderr,"Display map for what nation: ");
 		else fprintf(stderr,"What nation would you like to be: ");
-		gets(name);
+		if (fgets(name, NAMELTH+1, stdin) != NULL) {
+				name[strcspn(name, "\n")] = '\0';
+		}
 	}
 #ifdef OGOD
 	if(strcmp(name,"god")==0 || strcmp(name,"unowned")==0) {


### PR DESCRIPTION
* LOGIN define statement will now be the current user_id from the shell and obtained in the Makefile, instead than in header.h

* CHECKUSER as default, needs to be tested in a multiuser context.

* Compile with -lncurses

* Makefile reworked so the destination folders are created first.

* help files are copied instead of linked.

* Fix declarations of scenario and  datadir, since they are defined elsewhere: extern char datadir[FILELTH];

* main.c : Migrate from Pre-ANSI-C gets to ISO C99 fgets.