### PR TITLE
Add -lcrypt to Makefile to fix compiling on FreeBSD

### DIFF
--- a/gpl-release/Makefile
+++ b/gpl-release/Makefile
@@ -67,7 +67,7 @@ else ifeq ($(UNAME_S),Darwin)
     LTFLG = -h $(NCURSES_LIBS)
 else
     # BSD and other Unix-like systems
-    LIBRARIES = -lcurses -ltermcap
+    LIBRARIES = -lcurses -ltermcap -lcrypt
     LTFLG = -h -lcurses
 endif
 


### PR DESCRIPTION
Add -lcrypt to Makefile to fix compiling on FreeBSD